### PR TITLE
Try MonadTest instances without using extension

### DIFF
--- a/arrow-check/src/main/kotlin/arrow/check/Runner.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/Runner.kt
@@ -5,8 +5,8 @@ import arrow.check.gen.*
 import arrow.check.gen.instances.rose.birecursive.birecursive
 import arrow.check.property.*
 import arrow.check.property.Failure
+import arrow.check.property.instances.monadTest
 import arrow.check.property.instances.propertyt.applicativeError.handleErrorWith
-import arrow.check.property.instances.propertyt.monadTest.monadTest
 import arrow.core.*
 import arrow.core.extensions.id.traverse.traverse
 import arrow.core.extensions.list.functorFilter.filterMap

--- a/arrow-check/src/main/kotlin/arrow/check/gen/Coarbitrary.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/gen/Coarbitrary.kt
@@ -1,10 +1,6 @@
 package arrow.check.gen
 
 import arrow.core.*
-import arrow.extension
-import arrow.check.gen.either.coarbitrary.coarbitrary
-import arrow.check.gen.listk.coarbitrary.coarbitrary
-import arrow.check.gen.tuple2.coarbitrary.coarbitrary
 
 // @higherkind boilerplate
 class ForCoarbitrary private constructor() {
@@ -27,7 +23,7 @@ fun <M, B> GenT<M, B>.variant(i: Long): GenT<M, B> =
     GenT(AndThen(runGen).compose { (seed, size) -> seed.variant(i) toT size })
 
 // keep it here for now, maybe add that for TupleN later
-@extension
+// @extension
 interface Tuple2Coarbitrary<A, B> : Coarbitrary<Tuple2<A, B>> {
     fun CA(): Coarbitrary<A>
     fun CB(): Coarbitrary<B>
@@ -37,6 +33,11 @@ interface Tuple2Coarbitrary<A, B> : Coarbitrary<Tuple2<A, B>> {
                 coarbitrary(a.a).coarbitrary(a.b)
             }
         }
+}
+
+fun <A, B> Tuple2.Companion.coarbitrary(CA: Coarbitrary<A>, CB: Coarbitrary<B>): Coarbitrary<Tuple2<A, B>> = object : Tuple2Coarbitrary<A, B> {
+    override fun CA(): Coarbitrary<A> = CA
+    override fun CB(): Coarbitrary<B> = CB
 }
 
 fun unitCoarbitrary(): Coarbitrary<Unit> = object : Coarbitrary<Unit> {
@@ -102,7 +103,7 @@ interface StringCoarbitrary : Coarbitrary<String> {
 
 fun String.Companion.coarbitrary(): Coarbitrary<String> = object: StringCoarbitrary {}
 
-@extension
+// @extension
 interface ListKCoarbitrary<A> : Coarbitrary<ListK<A>> {
     fun AC(): Coarbitrary<A>
     override fun <M, B> GenT<M, B>.coarbitrary(a: ListK<A>): GenT<M, B> =
@@ -113,7 +114,11 @@ interface ListKCoarbitrary<A> : Coarbitrary<ListK<A>> {
         }
 }
 
-@extension
+fun <A> ListK.Companion.coarbitrary(CA: Coarbitrary<A>): Coarbitrary<ListK<A>> = object : ListKCoarbitrary<A> {
+    override fun AC(): Coarbitrary<A> = CA
+}
+
+// @extension
 interface NonEmptyListCoarbitrary<A> : Coarbitrary<NonEmptyList<A>> {
     fun AC(): Coarbitrary<A>
     override fun <M, B> GenT<M, B>.coarbitrary(a: Nel<A>): GenT<M, B> =
@@ -122,7 +127,11 @@ interface NonEmptyListCoarbitrary<A> : Coarbitrary<NonEmptyList<A>> {
         }
 }
 
-@extension
+fun <A> NonEmptyList.Companion.coarbitrary(CA: Coarbitrary<A>): Coarbitrary<NonEmptyList<A>> = object : NonEmptyListCoarbitrary<A> {
+    override fun AC(): Coarbitrary<A> = CA
+}
+
+// @extension
 interface OptionCoarbitrary<A> : Coarbitrary<Option<A>> {
     fun AC(): Coarbitrary<A>
     override fun <M, B> GenT<M, B>.coarbitrary(a: Option<A>): GenT<M, B> =
@@ -133,7 +142,11 @@ interface OptionCoarbitrary<A> : Coarbitrary<Option<A>> {
         })
 }
 
-@extension
+fun <A> Option.Companion.coarbitrary(CA: Coarbitrary<A>): Coarbitrary<Option<A>> = object : OptionCoarbitrary<A> {
+    override fun AC(): Coarbitrary<A> = CA
+}
+
+// @extension
 interface EitherCoarbitrary<L, R> : Coarbitrary<Either<L, R>> {
     fun LC(): Coarbitrary<L>
     fun RC(): Coarbitrary<R>
@@ -145,21 +158,34 @@ interface EitherCoarbitrary<L, R> : Coarbitrary<Either<L, R>> {
         })
 }
 
-@extension
+fun <L, R> Either.Companion.coarbitrary(LC: Coarbitrary<L>, RC: Coarbitrary<R>): Coarbitrary<Either<L, R>> = object : EitherCoarbitrary<L, R> {
+    override fun LC(): Coarbitrary<L> = LC
+    override fun RC(): Coarbitrary<R> = RC
+}
+
+// @extension
 interface ConstCoarbitrary<A, T> : Coarbitrary<Const<A, T>> {
     fun AC(): Coarbitrary<A>
     override fun <M, B> GenT<M, B>.coarbitrary(a: Const<A, T>): GenT<M, B> =
         AC().run { coarbitrary(a.value()) }
 }
 
-@extension
+fun <A, T> Const.Companion.coarbitrary(AC: Coarbitrary<A>): Coarbitrary<Const<A, T>> = object : ConstCoarbitrary<A, T> {
+    override fun AC(): Coarbitrary<A> = AC
+}
+
+// @extension
 interface IdCoarbitrary<A> : Coarbitrary<Id<A>> {
     fun AC(): Coarbitrary<A>
     override fun <M, B> GenT<M, B>.coarbitrary(a: Id<A>): GenT<M, B> =
         AC().run { coarbitrary(a.value()) }
 }
 
-@extension
+fun <A> Id.Companion.coarbitrary(AC: Coarbitrary<A>): Coarbitrary<Id<A>> = object : IdCoarbitrary<A> {
+    override fun AC(): Coarbitrary<A> = AC
+}
+
+// @extension
 interface IorCoarbitrary<L, R> : Coarbitrary<Ior<L, R>> {
     fun LC(): Coarbitrary<L>
     fun RC(): Coarbitrary<R>
@@ -177,7 +203,12 @@ interface IorCoarbitrary<L, R> : Coarbitrary<Ior<L, R>> {
         })
 }
 
-@extension
+fun <L, R> Ior.Companion.coarbitrary(LC: Coarbitrary<L>, RC: Coarbitrary<R>): Coarbitrary<Ior<L, R>> = object : IorCoarbitrary<L, R> {
+    override fun LC(): Coarbitrary<L> = LC
+    override fun RC(): Coarbitrary<R> = RC
+}
+
+// @extension
 interface MapKCoarbitrary<K, V> : Coarbitrary<MapK<K, V>> {
     fun KC(): Coarbitrary<K>
     fun VC(): Coarbitrary<V>
@@ -187,7 +218,12 @@ interface MapKCoarbitrary<K, V> : Coarbitrary<MapK<K, V>> {
         }
 }
 
-@extension
+fun <K, V> MapK.Companion.coarbitrary(KC: Coarbitrary<K>, VC: Coarbitrary<V>): Coarbitrary<MapK<K, V>> = object : MapKCoarbitrary<K, V> {
+    override fun KC(): Coarbitrary<K> = KC
+    override fun VC(): Coarbitrary<V> = VC
+}
+
+// @extension
 interface SetKCoarbitrary<V> : Coarbitrary<SetK<V>> {
     fun VC(): Coarbitrary<V>
     override fun <M, B> GenT<M, B>.coarbitrary(a: SetK<V>): GenT<M, B> =
@@ -196,13 +232,21 @@ interface SetKCoarbitrary<V> : Coarbitrary<SetK<V>> {
         }
 }
 
-@extension
+fun <V> SetK.Companion.coarbitrary(VC: Coarbitrary<V>): Coarbitrary<SetK<V>> = object : SetKCoarbitrary<V> {
+    override fun VC(): Coarbitrary<V> = VC
+}
+
+// @extension
 interface SequenceKCoarbitrary<A> : Coarbitrary<SequenceK<A>> {
     fun AC(): Coarbitrary<A>
     override fun <M, B> GenT<M, B>.coarbitrary(a: SequenceK<A>): GenT<M, B> =
         ListK.coarbitrary(AC()).run {
             coarbitrary(a.toList().k())
         }
+}
+
+fun <A> SequenceK.Companion.coarbitrary(AC: Coarbitrary<A>): Coarbitrary<SequenceK<A>> = object : SequenceKCoarbitrary<A> {
+    override fun AC(): Coarbitrary<A> = AC
 }
 
 interface SortedMapKCoarbitrary<K: Comparable<K>, V> : Coarbitrary<SortedMapK<K, V>> {
@@ -220,8 +264,8 @@ fun <K: Comparable<K>, V> SortedMapK.Companion.coarbitrary(KC: Coarbitrary<K>, V
         override fun VC(): Coarbitrary<V> = VC
     }
 
-@extension
-interface VaidatedCoarbitrary<E, A> : Coarbitrary<Validated<E, A>> {
+// @extension
+interface ValidatedCoarbitrary<E, A> : Coarbitrary<Validated<E, A>> {
     fun EC(): Coarbitrary<E>
     fun AC(): Coarbitrary<A>
     override fun <M, B> GenT<M, B>.coarbitrary(a: Validated<E, A>): GenT<M, B> =
@@ -234,4 +278,9 @@ interface VaidatedCoarbitrary<E, A> : Coarbitrary<Validated<E, A>> {
                 variant(2).coarbitrary(it)
             }
         })
+}
+
+fun <E, A> Validated.Companion.coarbitrary(EC: Coarbitrary<E>, AC: Coarbitrary<A>): Coarbitrary<Validated<E, A>> = object : ValidatedCoarbitrary<E, A> {
+    override fun AC(): Coarbitrary<A> = AC
+    override fun EC(): Coarbitrary<E> = EC
 }

--- a/arrow-check/src/main/kotlin/arrow/check/gen/Function.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/gen/Function.kt
@@ -1,24 +1,18 @@
 package arrow.check.gen
 
 import arrow.Kind
-import arrow.check.gen.either.func.func
-import arrow.check.gen.fn.functor.functor
-import arrow.check.gen.fn.functor.map
-import arrow.check.gen.instances.gent.applicative.applicative
-import arrow.check.gen.listk.func.func
-import arrow.check.gen.option.func.func
-import arrow.check.gen.tuple2.func.func
+import arrow.check.gen.instances.applicative
 import arrow.core.*
 import arrow.core.extensions.eval.monad.flatten
 import arrow.core.extensions.id.monad.monad
 import arrow.core.extensions.list.functorFilter.filterMap
-import arrow.extension
 import arrow.mtl.OptionT
 import arrow.mtl.OptionTPartialOf
 import arrow.mtl.extensions.optiont.applicative.applicative
 import arrow.mtl.extensions.optiont.monad.monad
 import arrow.mtl.value
 import arrow.recursion.pattern.ListF
+import arrow.recursion.pattern.NonEmptyListF
 import arrow.syntax.collections.tail
 import arrow.typeclasses.Functor
 import arrow.typeclasses.Show
@@ -45,7 +39,7 @@ class Fun<A, B>(val d: B, val fn: Fn<A, Rose<OptionTPartialOf<ForId>, B>>) : Fun
     companion object
 }
 
-@extension
+// @extension
 interface FunShow<A, B> : Show<Fun<A, B>> {
     fun SA(): Show<A>
     fun SB(): Show<B>
@@ -60,6 +54,11 @@ interface FunShow<A, B> : Show<Fun<A, B>> {
                     SA().run { k.show() } + " -> " + SB().run { v.show() }
                 } + listOf("_ -> " + SB().run { d.show() })
         }.toString()
+}
+
+fun <A, B> Fun.Companion.show(SA: Show<A>, SB: Show<B>): Show<Fun<A, B>> = object : FunShow<A, B> {
+    override fun SA(): Show<A> = SA
+    override fun SB(): Show<B> = SB
 }
 
 // Gen instance
@@ -98,7 +97,7 @@ sealed class Fn<A, B> : FnOf<A, B> {
 }
 
 // Typesafety? No.
-@extension
+// @extension
 interface FnFunctor<C> : Functor<FnPartialOf<C>> {
     override fun <A, B> Kind<FnPartialOf<C>, A>.map(f: (A) -> B): Kind<FnPartialOf<C>, B> = when (val t = this.fix()) {
         is Fn.UnitFn -> Fn.UnitFn(f(t.b)) as Fn<C, B> // Safe because C == Unit, god I wish we had gadts here
@@ -117,6 +116,8 @@ interface FnFunctor<C> : Functor<FnPartialOf<C>> {
     }
 }
 
+fun <C> Fn.Companion.functor(): Functor<FnPartialOf<C>> = object : FnFunctor<C> {}
+
 // fn gen
 fun <A, B> GenTOf<ForId, B>.toFunction(AF: Func<A>, AC: Coarbitrary<A>): Gen<Fun<A, B>> =
     Gen.applicative(Id.monad()).mapN(
@@ -124,7 +125,7 @@ fun <A, B> GenTOf<ForId, B>.toFunction(AF: Func<A>, AC: Coarbitrary<A>): Gen<Fun
         Gen { (s, sz) ->
             Rose.unfold(
                 OptionT.monad(Id.monad()),
-                AF.function { a -> AC.run { this@toFunction.fix().coarbitrary(a) } }.map { it.runGen(s toT sz) }
+                Fn.functor<A>().run { AF.function { a -> AC.run { this@toFunction.fix().coarbitrary(a) } }.map { it.runGen(s toT sz) } }.fix()
             ) {
                 shrinkFun(it) { it.runRose.value().value().fold({ emptySequence() }, { it.shrunk }) }
             }
@@ -135,8 +136,8 @@ fun <A, B> abstract(fn: Fn<A, B>, d: B): Function1<A, Eval<B>> = when (fn) {
     is Fn.UnitFn -> Function1 { Eval.now(fn.b) }
     is Fn.NilFn -> Function1 { Eval.now(d) }
     is Fn.PairFn<*, *, B> -> Function1 { (x, y): Tuple2<Any?, Any?> ->
-        Fn.functor<B>().run {
-            abstract(fn.fn.map { (abstract(it, d).f as (Any?) -> Eval<B>)(y) }, Eval.now(d)).f(x).flatten().fix()
+        Fn.functor<Any?>().run {
+            abstract(fn.fn.map { (abstract(it, d).f as (Any?) -> Eval<B>)(y) }.fix(), Eval.now(d)).f(x).flatten().fix()
         }
     } as Function1<A, Eval<B>>
     is Fn.EitherFn<*, *, B> -> Function1 { e: Either<Any?, Any?> ->
@@ -236,7 +237,9 @@ private fun <A, B, C> ((Tuple2<A, B>) -> C).curry(): ((A) -> ((B) -> C)) =
 fun <A, B, C> funPair(fA: Func<A>, fB: Func<B>, f: (Tuple2<A, B>) -> C): Fn<Tuple2<A, B>, C> = fA.run {
     fB.run {
         Fn.PairFn(
-            function(f.curry()).map { function(it) }
+            Fn.functor<A>().run {
+                function(f.curry()).map { function(it) }.fix()
+            }
         )
     }
 }
@@ -253,7 +256,7 @@ fun unitFunc(): Func<Unit> = object : Func<Unit> {
     override fun <B> function(f: (Unit) -> B): Fn<Unit, B> = Fn.UnitFn(f(Unit))
 }
 
-@extension
+// @extension
 interface Tuple2Func<A, B> : Func<Tuple2<A, B>> {
     fun AF(): Func<A>
     fun BF(): Func<B>
@@ -262,12 +265,22 @@ interface Tuple2Func<A, B> : Func<Tuple2<A, B>> {
         funPair(AF(), BF(), f)
 }
 
-@extension
+fun <A, B> Tuple2.Companion.func(AF: Func<A>, BF: Func<B>): Func<Tuple2<A, B>> = object : Tuple2Func<A, B> {
+    override fun AF(): Func<A> = AF
+    override fun BF(): Func<B> = BF
+}
+
+// @extension
 interface EitherFunc<L, R> : Func<Either<L, R>> {
     fun LF(): Func<L>
     fun RF(): Func<R>
 
     override fun <B> function(f: (Either<L, R>) -> B): Fn<Either<L, R>, B> = funEither(LF(), RF(), f)
+}
+
+fun <L, R> Either.Companion.func(LF: Func<L>, RF: Func<R>): Func<Either<L, R>> = object : EitherFunc<L, R> {
+    override fun LF(): Func<L> = LF
+    override fun RF(): Func<R> = RF
 }
 
 interface BooleanFunc : Func<Boolean> {
@@ -334,7 +347,7 @@ private fun Long.toByteList(): List<UByte> = when (this) {
     else -> listOf(this.and(UByte.MAX_VALUE.toLong()).toUByte()) + this.ushr(8).toByteList()
 }
 
-@extension
+// @extension
 interface OptionFunc<A> : Func<Option<A>> {
     fun AF(): Func<A>
     override fun <B> function(f: (Option<A>) -> B): Fn<Option<A>, B> =
@@ -343,6 +356,10 @@ interface OptionFunc<A> : Func<Option<A>> {
         }, {
             it.toOption()
         }, f)
+}
+
+fun <A> Option.Companion.func(AF: Func<A>): Func<Option<A>> = object : OptionFunc<A> {
+    override fun AF(): Func<A> = AF
 }
 
 // Model haskell lists to prevent overflows with strict lists
@@ -378,7 +395,7 @@ interface StreamFunc<A> : Func<Stream<A>> {
         }, f)
 }
 
-@extension
+// @extension
 interface ListKFunc<A> : Func<ListK<A>> {
     fun AF(): Func<A>
     override fun <B> function(f: (ListK<A>) -> B): Fn<ListK<A>, B> =
@@ -387,6 +404,10 @@ interface ListKFunc<A> : Func<ListK<A>> {
                 acc.map { (listOf(v) + it).k() }
             }.value()
         }, f)
+}
+
+fun <A> ListK.Companion.func(AF: Func<A>): Func<ListK<A>> = object : ListKFunc<A> {
+    override fun AF(): Func<A> = AF
 }
 
 interface IntFunc : Func<Int> {
@@ -427,21 +448,29 @@ interface FloatFunc : Func<Float> {
 
 fun Float.Companion.func(): Func<Float> = object : FloatFunc {}
 
-@extension
+// @extension
 interface ConstFunc<A, T> : Func<Const<A, T>> {
     fun AF(): Func<A>
     override fun <B> function(f: (Const<A, T>) -> B): Fn<Const<A, T>, B> =
         funMap(AF(), { it.value() }, { Const(it) }, f)
 }
 
-@extension
+fun <A, T> Const.Companion.func(AF: Func<A>): Func<Const<A, T>> = object : ConstFunc<A, T> {
+    override fun AF(): Func<A> = AF
+}
+
+// @extension
 interface IdFunc<A> : Func<Id<A>> {
     fun AF(): Func<A>
     override fun <B> function(f: (Id<A>) -> B): Fn<Id<A>, B> =
         funMap(AF(), { it.value() }, ::Id, f)
 }
 
-@extension
+fun <A> Id.Companion.func(AF: Func<A>): Func<Id<A>> = object : IdFunc<A> {
+    override fun AF(): Func<A> = AF
+}
+
+// @extension
 interface IorFunc<A, C> : Func<Ior<A, C>> {
     fun AF(): Func<A>
     fun BF(): Func<C>
@@ -461,7 +490,12 @@ interface IorFunc<A, C> : Func<Ior<A, C>> {
         }, f)
 }
 
-@extension
+fun <A, C> Ior.Companion.func(AF: Func<A>, CF: Func<C>): Func<Ior<A, C>> = object : IorFunc<A, C> {
+    override fun AF(): Func<A> = AF
+    override fun BF(): Func<C> = CF
+}
+
+// @extension
 interface MapKFunc<K, V> : Func<MapK<K, V>> {
     fun KF(): Func<K>
     fun VF(): Func<V>
@@ -473,8 +507,13 @@ interface MapKFunc<K, V> : Func<MapK<K, V>> {
         }, f)
 }
 
-@extension
-interface SetVFunc<V> : Func<SetK<V>> {
+fun <K, V> MapK.Companion.func(KF: Func<K>, VF: Func<V>): Func<MapK<K, V>> = object : MapKFunc<K, V> {
+    override fun KF(): Func<K> = KF
+    override fun VF(): Func<V> = VF
+}
+
+// @extension
+interface SetKFunc<V> : Func<SetK<V>> {
     fun VF(): Func<V>
     override fun <B> function(f: (SetK<V>) -> B): Fn<SetK<V>, B> =
         funMap(ListK.func(VF()), {
@@ -484,7 +523,11 @@ interface SetVFunc<V> : Func<SetK<V>> {
         }, f)
 }
 
-@extension
+fun <V> SetK.Companion.func(VF: Func<V>): Func<SetK<V>> = object : SetKFunc<V> {
+    override fun VF(): Func<V> = VF
+}
+
+// @extension
 interface NonEmptyListFunc<A> : Func<NonEmptyList<A>> {
     fun AF(): Func<A>
     override fun <B> function(f: (Nel<A>) -> B): Fn<Nel<A>, B> =
@@ -495,7 +538,11 @@ interface NonEmptyListFunc<A> : Func<NonEmptyList<A>> {
         }, f)
 }
 
-@extension
+fun <A> NonEmptyList.Companion.func(AF: Func<A>): Func<NonEmptyList<A>> = object : NonEmptyListFunc<A> {
+    override fun AF(): Func<A> = AF
+}
+
+// @extension
 interface SequenceKFunc<A> : Func<SequenceK<A>> {
     fun AF(): Func<A>
     override fun <B> function(f: (SequenceK<A>) -> B): Fn<SequenceK<A>, B> =
@@ -504,6 +551,10 @@ interface SequenceKFunc<A> : Func<SequenceK<A>> {
         }, {
             it.asSequence().k()
         }, f)
+}
+
+fun <A> SequenceK.Companion.func(AF: Func<A>): Func<SequenceK<A>> = object : SequenceKFunc<A> {
+    override fun AF(): Func<A> = AF
 }
 
 interface SortedMapKFunc<K : Comparable<K>, V> : Func<SortedMapK<K, V>> {
@@ -523,7 +574,7 @@ fun <K : Comparable<K>, V> SortedMapK.Companion.func(KF: Func<K>, VF: Func<V>): 
         override fun VF(): Func<V> = VF
     }
 
-@extension
+// @extension
 interface ValidatedFunc<E, A> : Func<Validated<E, A>> {
     fun EF(): Func<E>
     fun AF(): Func<A>
@@ -531,6 +582,12 @@ interface ValidatedFunc<E, A> : Func<Validated<E, A>> {
         funMap(Either.func(EF(), AF()), { it.toEither() }, {
             it.fold(::Invalid, ::Valid)
         }, f)
+}
+
+
+fun <E, A> Validated.Companion.func(EF: Func<E>, AF: Func<A>): Func<Validated<E, A>> = object : ValidatedFunc<E, A> {
+    override fun AF(): Func<A> = AF
+    override fun EF(): Func<E> = EF
 }
 
 interface StringFunc : Func<String> {

--- a/arrow-check/src/main/kotlin/arrow/check/gen/Gen.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/gen/Gen.kt
@@ -1,16 +1,7 @@
 package arrow.check.gen
 
 import arrow.Kind
-import arrow.check.gen.instances.gent.alternative.alternative
-import arrow.check.gen.instances.gent.applicative.applicative
-import arrow.check.gen.instances.gent.monad.monad
-import arrow.check.gen.instances.rose.alternative.alternative
-import arrow.check.gen.instances.rose.applicative.applicative
-import arrow.check.gen.instances.rose.birecursive.birecursive
-import arrow.check.gen.instances.rose.mFunctor.mFunctor
-import arrow.check.gen.instances.rose.monad.monad
-import arrow.check.gen.instances.rose.monadFilter.filterMap
-import arrow.check.gen.instances.rose.monadTrans.monadTrans
+import arrow.check.gen.instances.*
 import arrow.check.property.*
 import arrow.core.*
 import arrow.core.extensions.eval.monad.monad
@@ -393,7 +384,7 @@ interface MonadGen<M, B> : Monad<M>, MonadFilter<M>, Alternative<M> {
                 val (x, gen) = this@filterMap.scale { Size(2 * k + it.unSize) }.freeze().bind()
                 f(x).fold({ t(k + 1).bind() }, {
                     gen.toGenT()
-                        .mapTree { it.filterMap(OptionT.alternative(BM()), OptionT.monad(BM()), f) }
+                        .mapTree { Rose.monadFilter(OptionT.alternative(BM()), OptionT.monad(BM())).run { it.filterMap(f) }.fix() }
                         .fromGenT().bind()
                 })
             }

--- a/arrow-check/src/main/kotlin/arrow/check/gen/Rose.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/gen/Rose.kt
@@ -1,7 +1,7 @@
 package arrow.check.gen
 
 import arrow.Kind
-import arrow.check.gen.instances.rose.birecursive.birecursive
+import arrow.check.gen.instances.birecursive
 import arrow.core.*
 import arrow.core.extensions.fx
 import arrow.mtl.typeclasses.nest

--- a/arrow-check/src/main/kotlin/arrow/check/pretty/Diff.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/pretty/Diff.kt
@@ -1,6 +1,7 @@
 package arrow.check.pretty
 
 import arrow.Kind
+import arrow.check.property.Markup
 import arrow.core.*
 import arrow.core.extensions.fx
 import arrow.core.extensions.list.foldable.foldLeft
@@ -13,12 +14,7 @@ import arrow.syntax.collections.tail
 import arrow.typeclasses.Functor
 import kparsec.runParser
 import pretty.*
-import pretty.ansistyle.monoid.monoid
 import pretty.symbols.*
-import arrow.check.pretty.kvalue.eq.eq
-import arrow.check.pretty.valuediff.birecursive.birecursive
-import arrow.check.pretty.valuedifff.functor.functor
-import arrow.check.property.Markup
 import kotlin.math.min
 
 class ForValueDiffF private constructor()
@@ -55,7 +51,7 @@ sealed class ValueDiffF<out F> : ValueDiffFOf<F> {
     companion object
 }
 
-@extension
+// @extension
 interface ValueDiffFFunctor : Functor<ForValueDiffF> {
     override fun <A, B> Kind<ForValueDiffF, A>.map(f: (A) -> B): Kind<ForValueDiffF, B> = when (val d = fix()) {
         is ValueDiffF.ValueD -> ValueDiffF.ValueD(d.l, d.r)
@@ -69,16 +65,20 @@ interface ValueDiffFFunctor : Functor<ForValueDiffF> {
     }
 }
 
+fun ValueDiffF.Companion.functor(): Functor<ForValueDiffF> = object : ValueDiffFFunctor {}
+
 data class ValueDiff(val unDiff: ValueDiffF<ValueDiff>) {
     companion object
 }
 
-@extension
+// @extension
 interface ValueDiffBirecursive : Birecursive<ValueDiff, ForValueDiffF> {
     override fun FF(): Functor<ForValueDiffF> = ValueDiffF.functor()
     override fun ValueDiff.projectT(): Kind<ForValueDiffF, ValueDiff> = unDiff
     override fun Kind<ForValueDiffF, ValueDiff>.embedT(): ValueDiff = ValueDiff(this.fix())
 }
+
+fun ValueDiff.Companion.birecursive(): Birecursive<ValueDiff, ForValueDiffF> = object : ValueDiffBirecursive {}
 
 infix fun KValue.toDiff(other: KValue): ValueDiff = (this toT other).let { (a, b) ->
     when {

--- a/arrow-check/src/main/kotlin/arrow/check/pretty/Parser.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/pretty/Parser.kt
@@ -69,10 +69,12 @@ fun <A> A.showPretty(SA: Show<A> = Show.any()): Doc<Nothing> = SA.run {
     }, ::identity)
 }.doc().group()
 
-@extension
+// @extension
 interface KValueEq : Eq<KValue> {
     override fun KValue.eqv(b: KValue): Boolean = this == b
 }
+
+fun KValue.Companion.eq(): Eq<KValue> = object : KValueEq {}
 
 typealias Parser<A> = KParsecT<Nothing, String, Char, ForId, A>
 

--- a/arrow-check/src/main/kotlin/arrow/check/property/Property.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/property/Property.kt
@@ -1,13 +1,11 @@
 package arrow.check.property
 
 import arrow.check.gen.*
-import arrow.check.gen.`fun`.show.show
-import arrow.check.gen.instances.gent.functor.functor
-import arrow.check.gen.instances.gent.monad.monad
+import arrow.check.gen.instances.functor
+import arrow.check.gen.instances.monad
 import arrow.check.pretty.showPretty
 import arrow.check.property.instances.monadTest
-import arrow.check.property.instances.testt.monadTrans.monadTrans
-import arrow.check.property.log.monoid.monoid
+import arrow.check.property.instances.monadTrans
 import arrow.core.Id
 import arrow.core.extensions.id.monad.monad
 import arrow.fx.ForIO

--- a/arrow-check/src/main/kotlin/arrow/check/property/Property.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/property/Property.kt
@@ -5,7 +5,7 @@ import arrow.check.gen.`fun`.show.show
 import arrow.check.gen.instances.gent.functor.functor
 import arrow.check.gen.instances.gent.monad.monad
 import arrow.check.pretty.showPretty
-import arrow.check.property.instances.propertyt.monadTest.monadTest
+import arrow.check.property.instances.monadTest
 import arrow.check.property.instances.testt.monadTrans.monadTrans
 import arrow.check.property.log.monoid.monoid
 import arrow.core.Id

--- a/arrow-check/src/main/kotlin/arrow/check/property/PropertySyntax.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/property/PropertySyntax.kt
@@ -3,8 +3,8 @@ package arrow.check.property
 import arrow.Kind
 import arrow.check.gen.*
 import arrow.check.property.instances.PropertyTMonadTest
-import arrow.check.property.instances.propertyt.monad.monad
-import arrow.check.property.instances.propertyt.monadTrans.monadTrans
+import arrow.check.property.instances.monad
+import arrow.check.property.instances.monadTrans
 import arrow.core.Either
 import arrow.core.ForId
 import arrow.fx.ForIO

--- a/arrow-check/src/main/kotlin/arrow/check/property/TestT.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/property/TestT.kt
@@ -5,7 +5,6 @@ import arrow.check.pretty.ValueDiffF
 import arrow.check.pretty.diff
 import arrow.check.pretty.showPretty
 import arrow.check.pretty.toDoc
-import arrow.check.property.log.monoid.monoid
 import arrow.core.*
 import arrow.core.extensions.id.applicative.applicative
 import arrow.core.extensions.id.eq.eq

--- a/arrow-check/src/main/kotlin/arrow/check/property/Util.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/property/Util.kt
@@ -55,13 +55,15 @@ inline class Log(val unLog: List<JournalEntry>) {
     companion object
 }
 
-@extension
+// @extension
 interface LogMonoid: Monoid<Log> {
     override fun Log.combine(b: Log): Log = Log(
         ListK.monoid<JournalEntry>().run { unLog + b.unLog }
     )
     override fun empty(): Log = Log(ListK.empty())
 }
+
+fun Log.Companion.monoid(): Monoid<Log> = object : LogMonoid {}
 
 sealed class JournalEntry {
     // inputs forAll adds those

--- a/arrow-check/src/main/kotlin/arrow/check/property/instances/MonadTest.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/property/instances/MonadTest.kt
@@ -3,14 +3,16 @@ package arrow.check.property.instances
 import arrow.Kind
 import arrow.check.property.MonadTest
 import arrow.check.property.Test
-import arrow.extension
 import arrow.mtl.*
 import arrow.mtl.extensions.*
 import arrow.mtl.extensions.optiont.monadTrans.liftT
 import arrow.typeclasses.Monad
 import arrow.typeclasses.Monoid
 
-@extension
+fun <M> OptionT.Companion.monadTest(MT: MonadTest<M>): MonadTest<OptionTPartialOf<M>> = object : OptionTMonadTest<M> {
+    override fun MT(): MonadTest<M> = MT
+}
+
 interface OptionTMonadTest<M> : MonadTest<OptionTPartialOf<M>>, OptionTMonad<M> {
     override fun MF(): Monad<M> = MT()
     fun MT(): MonadTest<M>
@@ -19,7 +21,10 @@ interface OptionTMonadTest<M> : MonadTest<OptionTPartialOf<M>>, OptionTMonad<M> 
     }
 }
 
-@extension
+fun <M, L> EitherT.Companion.monadTest(MT: MonadTest<M>): MonadTest<EitherTPartialOf<M, L>> = object : EitherTMonadTest<M, L> {
+    override fun MT(): MonadTest<M> = MT
+}
+
 interface EitherTMonadTest<M, L> : MonadTest<EitherTPartialOf<M, L>>, EitherTMonad<M, L> {
     override fun MF(): Monad<M> = MT()
     fun MT(): MonadTest<M>
@@ -28,7 +33,10 @@ interface EitherTMonadTest<M, L> : MonadTest<EitherTPartialOf<M, L>>, EitherTMon
     }
 }
 
-@extension
+fun <M, D> Kleisli.Companion.monadTest(MT: MonadTest<M>): MonadTest<KleisliPartialOf<M, D>> = object : KleisliTMonadTest<M, D> {
+    override fun MT(): MonadTest<M> = MT
+}
+
 interface KleisliTMonadTest<M, D> : MonadTest<KleisliPartialOf<M, D>>, KleisliMonad<M, D> {
     override fun MF(): Monad<M> = MT()
     fun MT(): MonadTest<M>
@@ -37,7 +45,11 @@ interface KleisliTMonadTest<M, D> : MonadTest<KleisliPartialOf<M, D>>, KleisliMo
     }
 }
 
-@extension
+fun <M, W> WriterT.Companion.monadTest(MT: MonadTest<M>, MM: Monoid<W>): MonadTest<WriterTPartialOf<M, W>> = object : WriterTMonadTest<M, W> {
+    override fun MT(): MonadTest<M> = MT
+    override fun MM(): Monoid<W> = MM
+}
+
 interface WriterTMonadTest<M, W> : MonadTest<WriterTPartialOf<M, W>>, WriterTMonad<M, W> {
     override fun MM(): Monoid<W>
     override fun MF(): Monad<M> = MT()
@@ -48,7 +60,10 @@ interface WriterTMonadTest<M, W> : MonadTest<WriterTPartialOf<M, W>>, WriterTMon
     }
 }
 
-@extension
+fun <M, S> StateT.Companion.monadTest(MT: MonadTest<M>): MonadTest<StateTPartialOf<M, S>> = object : StateTMonadTest<M, S> {
+    override fun MT(): MonadTest<M> = MT
+}
+
 interface StateTMonadTest<M, S> : MonadTest<StateTPartialOf<M, S>>, StateTMonad<M, S> {
     override fun MF(): Monad<M> = MT()
     fun MT(): MonadTest<M>

--- a/arrow-check/src/main/kotlin/arrow/check/property/instances/PropertyT.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/property/instances/PropertyT.kt
@@ -75,7 +75,10 @@ interface PropertyTAlternative<M> : Alternative<PropertyTPartialOf<M>>, Property
         PropertyT(TestT.alternative(GenT.monad(MM()), GenT.alternative(MM())).run { fix().unPropertyT.orElse(b.fix().unPropertyT).fix() })
 }
 
-@extension
+fun <M> PropertyT.Companion.monadTest(MM: Monad<M>): MonadTest<PropertyTPartialOf<M>> = object : PropertyTMonadTest<M> {
+    override fun MM(): Monad<M> = MM
+}
+
 interface PropertyTMonadTest<M> : MonadTest<PropertyTPartialOf<M>>, PropertyTMonad<M> {
     override fun MM(): Monad<M>
 

--- a/arrow-check/src/main/kotlin/arrow/check/property/instances/TestT.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/property/instances/TestT.kt
@@ -3,36 +3,22 @@ package arrow.check.property.instances
 import arrow.Kind
 import arrow.Kind2
 import arrow.check.property.*
-import arrow.check.property.instances.testt.monad.flatMap
-import arrow.check.property.instances.testt.monad.monad
-import arrow.check.property.instances.testt.monadTrans.liftT
-import arrow.check.property.log.monoid.monoid
 import arrow.core.Either
-import arrow.core.Tuple2
-import arrow.extension
 import arrow.fx.IO
-import arrow.fx.RacePair
-import arrow.fx.RaceTriple
-import arrow.fx.mtl.concurrent
-import arrow.fx.mtl.eithert.async.async
-import arrow.fx.mtl.eithert.monadDefer.monadDefer
-import arrow.fx.mtl.writert.async.async
-import arrow.fx.mtl.writert.monadDefer.monadDefer
-import arrow.fx.typeclasses.*
-import arrow.mtl.*
-import arrow.mtl.extensions.eithert.functor.unit
+import arrow.fx.typeclasses.MonadIO
+import arrow.mtl.EitherT
+import arrow.mtl.WriterT
+import arrow.mtl.WriterTPartialOf
 import arrow.mtl.extensions.writert.applicative.applicative
 import arrow.mtl.extensions.writert.functor.functor
 import arrow.mtl.extensions.writert.monad.monad
 import arrow.mtl.extensions.writert.monadError.monadError
-import arrow.mtl.typeclasses.MonadReader
 import arrow.mtl.typeclasses.MonadTrans
-import arrow.mtl.typeclasses.MonadWriter
+import arrow.mtl.value
 import arrow.syntax.function.andThen
 import arrow.typeclasses.*
-import kotlin.coroutines.CoroutineContext
 
-@extension
+// @extension
 interface TestTFunctor<M> : Functor<TestTPartialOf<M>> {
     fun MM(): Monad<M>
 
@@ -40,7 +26,11 @@ interface TestTFunctor<M> : Functor<TestTPartialOf<M>> {
         fix().map(MM(), f)
 }
 
-@extension
+fun <M> TestT.Companion.functor(MM: Monad<M>): Functor<TestTPartialOf<M>> = object : TestTFunctor<M> {
+    override fun MM(): Monad<M> = MM
+}
+
+// @extension
 interface TestTApplicative<M> : Applicative<TestTPartialOf<M>> {
     fun MM(): Monad<M>
 
@@ -50,7 +40,11 @@ interface TestTApplicative<M> : Applicative<TestTPartialOf<M>> {
     override fun <A> just(a: A): Kind<TestTPartialOf<M>, A> = TestT.just(MM(), a)
 }
 
-@extension
+fun <M> TestT.Companion.appllicative(MM: Monad<M>): Applicative<TestTPartialOf<M>> = object : TestTApplicative<M> {
+    override fun MM(): Monad<M> = MM
+}
+
+// @extension
 interface TestTMonad<M> : Monad<TestTPartialOf<M>> {
     fun MM(): Monad<M>
 
@@ -70,26 +64,36 @@ interface TestTMonad<M> : Monad<TestTPartialOf<M>> {
         }
 }
 
-@extension
+fun <M> TestT.Companion.monad(MM: Monad<M>): Monad<TestTPartialOf<M>> = object : TestTMonad<M> {
+    override fun MM(): Monad<M> = MM
+}
+
+// @extension
 interface TestTAlternative<M> : Alternative<TestTPartialOf<M>>, TestTApplicative<M> {
     override fun MM(): Monad<M>
     fun AF(): Alternative<M>
-    override fun <A> empty(): Kind<TestTPartialOf<M>, A> = AF().empty<A>().liftT(MM())
+    override fun <A> empty(): Kind<TestTPartialOf<M>, A> = TestT.monadTrans().run { AF().empty<A>().liftT(MM()) }
     override fun <A> Kind<TestTPartialOf<M>, A>.orElse(b: Kind<TestTPartialOf<M>, A>): Kind<TestTPartialOf<M>, A> =
         TestT(EitherT(WriterT(AF().run { fix().runTestT.value().value().orElse(b.fix().runTestT.value().value()) })))
+}
+
+fun <M> TestT.Companion.alternative(MM: Monad<M>, AF: Alternative<M>): Alternative<TestTPartialOf<M>> = object : TestTAlternative<M> {
+    override fun AF(): Alternative<M> = AF
+    override fun MM(): Monad<M> = MM
+}
+
+interface TestTMonadTest<M> : MonadTest<TestTPartialOf<M>>, TestTMonad<M> {
+
+    override fun MM(): Monad<M>
+    override fun <A> Test<A>.liftTest(): Kind<TestTPartialOf<M>, A> = hoist(MM())
+
 }
 
 fun <M> TestT.Companion.monadTest(MM: Monad<M>): MonadTest<TestTPartialOf<M>> = object : TestTMonadTest<M> {
     override fun MM(): Monad<M> = MM
 }
 
-interface TestTMonadTest<M> : MonadTest<TestTPartialOf<M>>, TestTMonad<M> {
-    override fun MM(): Monad<M>
-
-    override fun <A> Test<A>.liftTest(): Kind<TestTPartialOf<M>, A> = hoist(MM())
-}
-
-@extension
+// @extension
 interface TestTMonadTrans : MonadTrans<ForTestT> {
     override fun <G, A> Kind<G, A>.liftT(MF: Monad<G>): Kind2<ForTestT, G, A> = TestT(
         EitherT.liftF<WriterTPartialOf<G, Log>, Failure, A>(
@@ -99,16 +103,24 @@ interface TestTMonadTrans : MonadTrans<ForTestT> {
     )
 }
 
-@extension
+fun TestT.Companion.monadTrans(): MonadTrans<ForTestT> = object : TestTMonadTrans {}
+
+// @extension
 interface TestTMonadIO<M> : MonadIO<TestTPartialOf<M>>, TestTMonad<M> {
     override fun MM(): Monad<M> = MIO()
     fun MIO(): MonadIO<M>
     override fun <A> IO<A>.liftIO(): Kind<TestTPartialOf<M>, A> = MIO().run {
-        liftIO().liftT(this)
+        TestT.monadTrans().run {
+            liftIO().liftT(MIO())
+        }
     }
 }
 
-@extension
+fun <M> TestT.Companion.monadIO(MIO: MonadIO<M>): MonadIO<TestTPartialOf<M>> = object : TestTMonadIO<M> {
+    override fun MIO(): MonadIO<M> = MIO
+}
+
+// @extension
 interface TestTApplicativeError<M, E> : ApplicativeError<TestTPartialOf<M>, E>, TestTApplicative<M> {
     override fun MM(): Monad<M> = ME()
     fun ME(): MonadError<M, E>
@@ -122,16 +134,26 @@ interface TestTApplicativeError<M, E> : ApplicativeError<TestTPartialOf<M>, E>, 
         }
 
     override fun <A> raiseError(e: E): Kind<TestTPartialOf<M>, A> =
-        ME().raiseError<A>(e).liftT(ME())
+        TestT.monadTrans().run {
+            ME().raiseError<A>(e).liftT(ME())
+        }
 }
 
-@extension
+fun <M, E> TestT.Companion.applicativeError(ME: MonadError<M, E>): ApplicativeError<TestTPartialOf<M>, E> = object : TestTApplicativeError<M, E> {
+    override fun ME(): MonadError<M, E> = ME
+}
+
+// @extension
 interface TestTMonadError<M, E> : MonadError<TestTPartialOf<M>, E>, TestTApplicativeError<M, E>, TestTMonad<M> {
     override fun MM(): Monad<M> = ME()
     override fun ME(): MonadError<M, E>
     override fun <A, B> Kind<TestTPartialOf<M>, A>.ap(ff: Kind<TestTPartialOf<M>, (A) -> B>): Kind<TestTPartialOf<M>, B> =
         fix().ap(ME(), ff.fix())
     override fun <A> just(a: A): Kind<TestTPartialOf<M>, A> = TestT.just(ME(), a)
+}
+
+fun <M, E> TestT.Companion.monadError(ME: MonadError<M, E>): MonadError<TestTPartialOf<M>, E> = object : TestTMonadError<M, E> {
+    override fun ME(): MonadError<M, E> = ME
 }
 
 // TODO when https://github.com/arrow-kt/arrow/pull/1981 is merged add MonadState etc

--- a/arrow-check/src/main/kotlin/arrow/check/property/instances/TestT.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/property/instances/TestT.kt
@@ -79,7 +79,10 @@ interface TestTAlternative<M> : Alternative<TestTPartialOf<M>>, TestTApplicative
         TestT(EitherT(WriterT(AF().run { fix().runTestT.value().value().orElse(b.fix().runTestT.value().value()) })))
 }
 
-@extension
+fun <M> TestT.Companion.monadTest(MM: Monad<M>): MonadTest<TestTPartialOf<M>> = object : TestTMonadTest<M> {
+    override fun MM(): Monad<M> = MM
+}
+
 interface TestTMonadTest<M> : MonadTest<TestTPartialOf<M>>, TestTMonad<M> {
     override fun MM(): Monad<M>
 

--- a/arrow-check/src/test/kotlin/arrow/check/gen/GenT.kt
+++ b/arrow-check/src/test/kotlin/arrow/check/gen/GenT.kt
@@ -1,13 +1,7 @@
 package arrow.check.gen
 
 import arrow.Kind
-import arrow.check.gen.instances.gent.alternative.alternative
-import arrow.check.gen.instances.gent.monad.monad
-import arrow.check.gen.instances.gent.monadError.monadError
-import arrow.check.gen.instances.gent.monadTrans.liftT
-import arrow.check.gen.instances.gent.monadTrans.monadTrans
-import arrow.check.gen.instances.gent.monoid.monoid
-import arrow.check.gen.instances.rose.eq.eq
+import arrow.check.gen.instances.*
 import arrow.check.property.Size
 import arrow.core.*
 import arrow.core.extensions.either.eqK.eqK
@@ -64,7 +58,7 @@ class GenTLawsSpec : UnitSpec() {
 
 fun <M> GenT.Companion.genK(genKF: GenK<M>, MM: Monad<M>): GenK<GenTPartialOf<M>> = object : GenK<GenTPartialOf<M>> {
     override fun <A> genK(gen: Gen<A>): Gen<Kind<GenTPartialOf<M>, A>> =
-        genKF.genK(gen).map { it.liftT(MM) }
+        genKF.genK(gen).map { GenT.monadTrans().run { it.liftT(MM) } }
 }
 
 /**

--- a/arrow-check/src/test/kotlin/arrow/check/gen/Rose.kt
+++ b/arrow-check/src/test/kotlin/arrow/check/gen/Rose.kt
@@ -1,16 +1,7 @@
 package arrow.check.gen
 
 import arrow.Kind
-import arrow.check.gen.instances.rose.applicative.applicative
-import arrow.check.gen.instances.rose.eq.eq
-import arrow.check.gen.instances.rose.eqK.eqK
-import arrow.check.gen.instances.rose.functor.functor
-import arrow.check.gen.instances.rose.monad.monad
-import arrow.check.gen.instances.rose.monadError.monadError
-import arrow.check.gen.instances.rose.monadTrans.liftT
-import arrow.check.gen.instances.rosef.eq.eq
-import arrow.check.gen.instances.rosef.eqK.eqK
-import arrow.check.gen.instances.rosef.traverse.traverse
+import arrow.check.gen.instances.*
 import arrow.core.*
 import arrow.core.extensions.either.eqK.eqK
 import arrow.core.extensions.either.monad.monad
@@ -77,5 +68,5 @@ fun <B> RoseF.Companion.genK(bGen: io.kotlintest.properties.Gen<B>): GenK<RoseFP
 // FIXME this should be a recusive gen, but with kotlintest that is not possible (with sufficient termination guarantees that is)
 fun <M> Rose.Companion.genK(genK: GenK<M>, MM: Monad<M>): GenK<RosePartialOf<M>> = object : GenK<RosePartialOf<M>> {
     override fun <A> genK(gen: io.kotlintest.properties.Gen<A>): io.kotlintest.properties.Gen<Kind<RosePartialOf<M>, A>> =
-        genK.genK(gen).map { it.liftT(MM) }
+        genK.genK(gen).map { Rose.monadTrans().run { it.liftT(MM) } }
 }


### PR DESCRIPTION
Let's see if this helps..

From what I can tell the compiler still needs quite a bit of memory to work through this ~1.5GB locally (if I looked at the right thing :see_no_evil: ).
I know far too less about the kotlin compiler to judge why that may be the case...