### PR TITLE
Upgrade to Kotlin 1.4.0

### DIFF
--- a/arrow-check-kotlintest/build.gradle
+++ b/arrow-check-kotlintest/build.gradle
@@ -7,8 +7,6 @@ apply from: "$SUB_PROJECT"
 apply from: "$DOC_CREATION"
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-
     implementation "io.arrow-kt:arrow-fx:$VERSION_NAME" // IO and arrow fx
     api project(":arrow-check")
 

--- a/arrow-check/build.gradle
+++ b/arrow-check/build.gradle
@@ -8,8 +8,6 @@ apply from: "$SUB_PROJECT"
 apply from: "$DOC_CREATION"
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-
     kapt "io.arrow-kt:arrow-meta:$VERSION_NAME" // auto generation for @extension and @higherkind
 
     // TODO do a pass on what is still needed and what not!
@@ -36,12 +34,5 @@ dependencies {
     testImplementation("io.arrow-kt:arrow-incubator-test:$VERSION_NAME") { // test helpers and laws
         exclude group: "io.kotlintest"
     }
-}
-
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:$KOTLIN_VERSION"
 }


### PR DESCRIPTION
# Changes

* Standard library is added automatically with the plugin now
* Add `kotlin-reflect` to fix dependency versions
* Remove unnecessary configuration (it's located in the main repository)