### PR TITLE
Unify Ktlint configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,6 @@
 # Some KtLint rules
 [*.{kt,kts}]
+indent_size=2
+insert_final_newline=true
+max_line_length=off
 disabled_rules=import-ordering,no-unit-return,curly-spacing,indent

--- a/arrow-check-kotlintest/src/main/kotlin/arrow/check/PropertySpec.kt
+++ b/arrow-check-kotlintest/src/main/kotlin/arrow/check/PropertySpec.kt
@@ -29,8 +29,8 @@ abstract class AbstractPropertySpec(f: AbstractPropertySpec.() -> Unit = {}) : A
         )
 
     operator fun String.invoke(
-        propertyConfig: PropertyConfig = PropertyConfig(),
-        c: suspend PropertyTestSyntax.() -> Unit
+      propertyConfig: PropertyConfig = PropertyConfig(),
+      c: suspend PropertyTestSyntax.() -> Unit
     ): Unit =
         addTestCase(
             this,
@@ -44,9 +44,9 @@ abstract class AbstractPropertySpec(f: AbstractPropertySpec.() -> Unit = {}) : A
         )
 
     operator fun String.invoke(
-        args: Config,
-        propertyConfig: PropertyConfig = PropertyConfig(),
-        c: suspend PropertyTestSyntax.() -> Unit
+      args: Config,
+      propertyConfig: PropertyConfig = PropertyConfig(),
+      c: suspend PropertyTestSyntax.() -> Unit
     ): Unit =
         addTestCase(
             this,

--- a/arrow-check/src/main/kotlin/arrow/check/Config.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/Config.kt
@@ -5,8 +5,8 @@ import arrow.fx.extensions.io.applicative.applicative
 import arrow.fx.fix
 
 data class Config(
-    val useColor: UseColor,
-    val verbose: Verbose
+  val useColor: UseColor,
+  val verbose: Verbose
 )
 
 sealed class Verbose {

--- a/arrow-check/src/main/kotlin/arrow/check/Report.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/Report.kt
@@ -54,10 +54,10 @@ import kotlin.math.floor
 import kotlin.math.max
 
 data class Report<out A>(
-    val numTests: TestCount,
-    val numDiscarded: DiscardCount,
-    val coverage: Coverage<CoverCount>,
-    val status: A
+  val numTests: TestCount,
+  val numDiscarded: DiscardCount,
+  val coverage: Coverage<CoverCount>,
+  val status: A
 ) {
     companion object
 }
@@ -76,12 +76,12 @@ sealed class Result {
 }
 
 data class FailureSummary(
-    val usedSize: Size,
-    val usedSeed: RandSeed,
-    val numShrinks: ShrinkCount,
-    val failureDoc: Doc<Markup>,
-    val annotations: List<FailureAnnotation>,
-    val footnotes: List<() -> Doc<Markup>>
+  val usedSize: Size,
+  val usedSeed: RandSeed,
+  val numShrinks: ShrinkCount,
+  val failureDoc: Doc<Markup>,
+  val annotations: List<FailureAnnotation>,
+  val footnotes: List<() -> Doc<Markup>>
 ) {
     companion object
 }
@@ -92,11 +92,11 @@ sealed class FailureAnnotation {
 }
 
 data class Summary(
-    val waiting: PropertyCount,
-    // val running: PropertyCount, TODO readd once I add execPar
-    val failed: PropertyCount,
-    val gaveUp: PropertyCount,
-    val successful: PropertyCount
+  val waiting: PropertyCount,
+  // val running: PropertyCount, TODO readd once I add execPar
+  val failed: PropertyCount,
+  val gaveUp: PropertyCount,
+  val successful: PropertyCount
 ) {
     companion object {
         fun monoid() = object : Monoid<Summary> {
@@ -122,10 +122,10 @@ data class Summary(
 inline class PropertyCount(val unPropertyCount: Int)
 
 data class ColumnWidth(
-    val percentage: Int,
-    val min: Int,
-    val name: Int,
-    val nameFail: Int
+  val percentage: Int,
+  val min: Int,
+  val name: Int,
+  val nameFail: Int
 ) {
     companion object {
         fun monoid(): Monoid<ColumnWidth> = object : Monoid<ColumnWidth> {
@@ -355,8 +355,8 @@ sealed class Style {
 // TODO this could be implemented with renderDecorated if that had nicer types
 fun SimpleDoc<Style>.renderMarkup(): String {
     tailrec fun SimpleDoc<Style>.go(
-        xs: List<Style>,
-        cont: (String) -> String
+      xs: List<Style>,
+      cont: (String) -> String
     ): String = when (val dF = unDoc.value()) {
         is SimpleDocF.Fail -> throw IllegalStateException("Encountered Fail in doc render. Please report this!")
         is SimpleDocF.Nil -> cont("")

--- a/arrow-check/src/main/kotlin/arrow/check/Runner.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/Runner.kt
@@ -96,15 +96,15 @@ fun checkGroup(config: Config, groupName: String, props: List<Tuple2<String, Pro
     }
 
 fun check(
-    propertyConfig: PropertyConfig = PropertyConfig(),
-    c: suspend PropertyTestSyntax.() -> Unit
+  propertyConfig: PropertyConfig = PropertyConfig(),
+  c: suspend PropertyTestSyntax.() -> Unit
 ): IO<Boolean> =
     check(property(propertyConfig, c))
 
 fun check(
-    config: Config,
-    propertyConfig: PropertyConfig = PropertyConfig(),
-    c: suspend PropertyTestSyntax.() -> Unit
+  config: Config,
+  propertyConfig: PropertyConfig = PropertyConfig(),
+  c: suspend PropertyTestSyntax.() -> Unit
 ): IO<Boolean> =
     check(config, property(propertyConfig, c))
 
@@ -117,19 +117,19 @@ fun recheck(size: Size, seed: RandSeed, prop: Property): IO<Unit> =
     detectConfig().flatMap { recheck(it, size, seed, prop) }
 
 fun recheck(
-    size: Size,
-    seed: RandSeed,
-    propertyConfig: PropertyConfig = PropertyConfig(),
-    c: suspend PropertyTestSyntax.() -> Unit
+  size: Size,
+  seed: RandSeed,
+  propertyConfig: PropertyConfig = PropertyConfig(),
+  c: suspend PropertyTestSyntax.() -> Unit
 ): IO<Unit> =
     recheck(size, seed, property(propertyConfig, c))
 
 fun recheck(
-    config: Config,
-    size: Size,
-    seed: RandSeed,
-    propertyConfig: PropertyConfig = PropertyConfig(),
-    c: suspend PropertyTestSyntax.() -> Unit
+  config: Config,
+  size: Size,
+  seed: RandSeed,
+  propertyConfig: PropertyConfig = PropertyConfig(),
+  c: suspend PropertyTestSyntax.() -> Unit
 ): IO<Unit> =
     recheck(config, size, seed, property(propertyConfig, c))
 
@@ -137,9 +137,9 @@ fun recheck(config: Config, size: Size, seed: RandSeed, prop: Property): IO<Unit
     checkReport(seed, size, config, None, prop).void()
 
 fun checkNamed(
-    name: String,
-    propertyConfig: PropertyConfig = PropertyConfig(),
-    c: suspend PropertyTestSyntax.() -> Unit
+  name: String,
+  propertyConfig: PropertyConfig = PropertyConfig(),
+  c: suspend PropertyTestSyntax.() -> Unit
 ): IO<Boolean> =
     checkNamed(name, property(propertyConfig, c))
 
@@ -147,10 +147,10 @@ fun checkNamed(name: String, prop: Property): IO<Boolean> =
     detectConfig().flatMap { check(it, PropertyName(name).some(), prop) }
 
 fun checkNamed(
-    config: Config,
-    name: String,
-    propertyConfig: PropertyConfig = PropertyConfig(),
-    c: suspend PropertyTestSyntax.() -> Unit
+  config: Config,
+  name: String,
+  propertyConfig: PropertyConfig = PropertyConfig(),
+  c: suspend PropertyTestSyntax.() -> Unit
 ): IO<Boolean> =
     check(config, PropertyName(name).some(), property(propertyConfig, c))
 
@@ -173,11 +173,11 @@ fun checkReport(config: Config, name: Option<PropertyName>, prop: Property): IO<
     }
 
 internal fun checkReport(
-    seed: RandSeed,
-    size: Size,
-    config: Config,
-    name: Option<PropertyName>,
-    prop: Property
+  seed: RandSeed,
+  size: Size,
+  config: Config,
+  name: Option<PropertyName>,
+  prop: Property
 ): IO<Report<Result>> =
     IO.fx {
         val report = !runProperty(IO.monadDefer(), size, seed, prop.config, prop.prop) {
@@ -190,21 +190,21 @@ internal fun checkReport(
 
 // ---------------- Running a single property
 data class State(
-    val numTests: TestCount,
-    val numDiscards: DiscardCount,
-    val size: Size,
-    val seed: RandSeed,
-    val coverage: Coverage<CoverCount>
+  val numTests: TestCount,
+  val numDiscards: DiscardCount,
+  val size: Size,
+  val seed: RandSeed,
+  val coverage: Coverage<CoverCount>
 )
 
 // TODO also clean this up... split it apart etc
 fun <M> runProperty(
-    MM: MonadDefer<M>,
-    initialSize: Size,
-    initialSeed: RandSeed,
-    config: PropertyConfig,
-    prop: PropertyT<M, Unit>,
-    hook: (Report<Progress>) -> Kind<M, Unit>
+  MM: MonadDefer<M>,
+  initialSize: Size,
+  initialSeed: RandSeed,
+  config: PropertyConfig,
+  prop: PropertyT<M, Unit>,
+  hook: (Report<Progress>) -> Kind<M, Unit>
 ): Kind<M, Report<Result>> {
     // Catch all errors M throws and report them using failException. This also catches all errors in all shrink branches the same way
     val wrappedProp = PropertyT.monadError(MM).run {
@@ -352,13 +352,13 @@ fun <M> runProperty(
 
 // TODO inline classes for params
 fun <M> shrinkResult(
-    MM: Monad<M>,
-    size: Size,
-    seed: RandSeed,
-    shrinkLimit: Int,
-    shrinkRetries: Int,
-    node: RoseF<Option<Tuple2<Log, Either<Failure, Unit>>>, Rose<M, Option<Tuple2<Log, Either<Failure, Unit>>>>>,
-    hook: (FailureSummary) -> Kind<M, Unit>
+  MM: Monad<M>,
+  size: Size,
+  seed: RandSeed,
+  shrinkLimit: Int,
+  shrinkRetries: Int,
+  node: RoseF<Option<Tuple2<Log, Either<Failure, Unit>>>, Rose<M, Option<Tuple2<Log, Either<Failure, Unit>>>>>,
+  hook: (FailureSummary) -> Kind<M, Unit>
 ): Kind<M, Result> = Rose.birecursive<M, Option<Tuple2<Log, Either<Failure, Unit>>>>(MM).run {
     Rose(MM.just(node)).hylo<Nested<M, RoseFPartialOf<Option<Tuple2<Log, Either<Failure, Unit>>>>>, Rose<M, Option<Tuple2<Log, Either<Failure, Unit>>>>, (ShrinkCount) -> Kind<M, Result>>(
         {
@@ -414,8 +414,8 @@ fun <M> shrinkResult(
 }
 
 fun <M, A, L, W> Rose<M, Option<Tuple2<W, Either<L, A>>>>.runTreeN(
-    MM: Monad<M>,
-    retries: Int
+  MM: Monad<M>,
+  retries: Int
 ): Kind<M, RoseF<Option<Tuple2<W, Either<L, A>>>, Rose<M, Option<Tuple2<W, Either<L, A>>>>>> =
     MM.fx.monad {
         val r = runRose.bind()

--- a/arrow-check/src/main/kotlin/arrow/check/gen/Gen.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/gen/Gen.kt
@@ -159,8 +159,8 @@ fun GenT.Companion.monadGen(): MonadGen<GenTPartialOf<ForId>, ForId> = object : 
 
     override fun <A> just(a: A): Kind<GenTPartialOf<ForId>, A> = MM().just(a)
     override fun <A, B> tailRecM(
-        a: A,
-        f: (A) -> Kind<GenTPartialOf<ForId>, Either<A, B>>
+      a: A,
+      f: (A) -> Kind<GenTPartialOf<ForId>, Either<A, B>>
     ): Kind<GenTPartialOf<ForId>, B> =
         MM().tailRecM(a, f)
 
@@ -398,9 +398,9 @@ interface MonadGen<M, B> : Monad<M>, MonadFilter<M>, Alternative<M> {
         }
 
     fun <A> recursive(
-        chooseFn: (List<Kind<M, A>>) -> Kind<M, A>,
-        nonRec: List<Kind<M, A>>,
-        rec: () -> List<Kind<M, A>>
+      chooseFn: (List<Kind<M, A>>) -> Kind<M, A>,
+      nonRec: List<Kind<M, A>>,
+      rec: () -> List<Kind<M, A>>
     ): Kind<M, A> =
         sized { s ->
             if (s.unSize <= 1) chooseFn(nonRec)

--- a/arrow-check/src/main/kotlin/arrow/check/gen/RandSeed.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/gen/RandSeed.kt
@@ -13,8 +13,8 @@ import arrow.core.toT
  *  I don't want to rely on reflection to get it!
  */
 class RandSeed private constructor(
-    val seed: Long,
-    val gamma: Long // Has to be odd!
+  val seed: Long,
+  val gamma: Long // Has to be odd!
 ) {
 
     override fun toString(): String = "RandSeed($seed, $gamma)"

--- a/arrow-check/src/main/kotlin/arrow/check/gen/instances/MonadGen.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/gen/instances/MonadGen.kt
@@ -138,10 +138,10 @@ interface MonadTransDistributive<G> {
      *  the type returned (by using something like .let {} to let intellij display it nicely.
      */
     fun <F, M, A> Kind2<G, Kind<F, M>, A>.distributeT(
-        MTF: MonadTrans<F>,
-        MFunc: MFunctor<F>,
-        MM: Monad<M>,
-        MT: MonadFromMonadTrans<F>
+      MTF: MonadTrans<F>,
+      MFunc: MFunctor<F>,
+      MM: Monad<M>,
+      MT: MonadFromMonadTrans<F>
     ): Kind2<F, Kind<G, M>, A>
 
     interface MonadFromMonadTrans<F> {
@@ -152,10 +152,10 @@ interface MonadTransDistributive<G> {
 // @extension
 interface OptionTMonadTransDistributive : MonadTransDistributive<ForOptionT> {
     override fun <F, M, A> Kind2<ForOptionT, Kind<F, M>, A>.distributeT(
-        MTF: MonadTrans<F>,
-        MFunc: MFunctor<F>,
-        MM: Monad<M>,
-        MT: MonadTransDistributive.MonadFromMonadTrans<F>
+      MTF: MonadTrans<F>,
+      MFunc: MFunctor<F>,
+      MM: Monad<M>,
+      MT: MonadTransDistributive.MonadFromMonadTrans<F>
     ): Kind2<F, Kind<ForOptionT, M>, A> =
         MFunc.run {
             fix().value().hoist(MM, object : FunctionK<M, OptionTPartialOf<M>> {
@@ -175,10 +175,10 @@ fun OptionT.Companion.monadTransDistributive(): MonadTransDistributive<ForOption
 // @extension
 interface RoseMonadTransDistributive : MonadTransDistributive<ForRose> {
     override fun <F, M, A> Kind2<ForRose, Kind<F, M>, A>.distributeT(
-        MTF: MonadTrans<F>,
-        MFunc: MFunctor<F>,
-        MM: Monad<M>,
-        MT: MonadTransDistributive.MonadFromMonadTrans<F>
+      MTF: MonadTrans<F>,
+      MFunc: MFunctor<F>,
+      MM: Monad<M>,
+      MT: MonadTransDistributive.MonadFromMonadTrans<F>
     ): Kind2<F, Kind<ForRose, M>, A> = MFunc.run {
         fix().runRose.hoist(MM, object : FunctionK<M, RosePartialOf<M>> {
             override fun <A> invoke(fa: Kind<M, A>): Kind<RosePartialOf<M>, A> = Rose.monadTrans().run { fa.liftT(MM) }
@@ -206,10 +206,10 @@ fun Rose.Companion.monadTransDistributive(): MonadTransDistributive<ForRose> = o
 interface GenTMonadTransDistributive : MonadTransDistributive<ForGenT> {
 
     override fun <F, M, A> Kind2<ForGenT, Kind<F, M>, A>.distributeT(
-        MTF: MonadTrans<F>,
-        MFunc: MFunctor<F>,
-        MM: Monad<M>,
-        MT: MonadTransDistributive.MonadFromMonadTrans<F>
+      MTF: MonadTrans<F>,
+      MFunc: MFunctor<F>,
+      MM: Monad<M>,
+      MT: MonadTransDistributive.MonadFromMonadTrans<F>
     ): Kind2<F, Kind<ForGenT, M>, A> = GenT(AndThen(fix().runGen).andThen {
         Rose.mFunctor().run {
             it.hoist(

--- a/arrow-check/src/main/kotlin/arrow/check/gen/instances/Rose.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/gen/instances/Rose.kt
@@ -70,8 +70,8 @@ fun <C> RoseF.Companion.foldable(): Foldable<RoseFPartialOf<C>> = object : RoseF
 // @extension
 interface RoseFTraverse<C> : Traverse<RoseFPartialOf<C>>, RoseFFoldable<C> {
     override fun <G, A, B> Kind<RoseFPartialOf<C>, A>.traverse(
-        AP: Applicative<G>,
-        f: (A) -> Kind<G, B>
+      AP: Applicative<G>,
+      f: (A) -> Kind<G, B>
     ): Kind<G, Kind<RoseFPartialOf<C>, B>> = AP.run {
         fix().shrunk.traverse(AP, f).map {
             RoseF(fix().res, it.fix())

--- a/arrow-check/src/main/kotlin/arrow/check/property/Property.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/property/Property.kt
@@ -133,9 +133,9 @@ fun <M, A> discard(MM: Monad<M>): PropertyT<M, A> =
     )
 
 fun <M, A, B> forAllFn(
-    gen: Gen<Fun<A, B>>,
-    MM: Monad<M>,
-    SA: Show<A> = Show.any(),
-    SB: Show<B> = Show.any()
+  gen: Gen<Fun<A, B>>,
+  MM: Monad<M>,
+  SA: Show<A> = Show.any(),
+  SB: Show<B> = Show.any()
 ): PropertyT<M, (A) -> B> =
     forAll(gen, MM, Fun.show(SA, SB)).map(MM) { it.component1() }

--- a/arrow-check/src/main/kotlin/arrow/check/property/PropertySyntax.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/property/PropertySyntax.kt
@@ -52,8 +52,8 @@ class PropertyTestContinuation<A> : MonadContinuation<PropertyTPartialOf<ForIO>,
         PropertyT.monad(MM()).just(a)
 
     override fun <A, B> tailRecM(
-        a: A,
-        f: (A) -> Kind<PropertyTPartialOf<ForIO>, Either<A, B>>
+      a: A,
+      f: (A) -> Kind<PropertyTPartialOf<ForIO>, Either<A, B>>
     ): Kind<PropertyTPartialOf<ForIO>, B> =
         PropertyT.monad(MM()).tailRecM(a, f)
 
@@ -83,9 +83,9 @@ interface PropertyTest<M> : PropertyTMonadTest<M> {
         forAll(gen, MM(), SA)
 
     fun <A, B> forAllFn(
-        gen: Gen<Fun<A, B>>,
-        SA: Show<A> = Show.any(),
-        SB: Show<B> = Show.any()
+      gen: Gen<Fun<A, B>>,
+      SA: Show<A> = Show.any(),
+      SB: Show<B> = Show.any()
     ): PropertyT<M, (A) -> B> =
         forAllFn(gen, MM(), SA, SB)
 
@@ -102,9 +102,9 @@ interface PropertyTest<M> : PropertyTMonadTest<M> {
         forAll(GenT.monadGen().f().fix(), SA)
 
     fun <A, B> forAllFn(
-        SA: Show<A> = Show.any(),
-        SB: Show<B> = Show.any(),
-        f: MonadGen<GenTPartialOf<ForId>, ForId>.() -> GenTOf<ForId, Fun<A, B>>
+      SA: Show<A> = Show.any(),
+      SB: Show<B> = Show.any(),
+      f: MonadGen<GenTPartialOf<ForId>, ForId>.() -> GenTOf<ForId, Fun<A, B>>
     ) =
         forAllFn(GenT.monadGen().f().fix(), SA, SB)
 

--- a/arrow-check/src/main/kotlin/arrow/check/property/TestT.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/property/TestT.kt
@@ -166,11 +166,11 @@ interface MonadTest<M> : Monad<M> {
         diff(this, other, SA) { a, b -> EQA.run { a.neqv(b) } }
 
     fun <A, B> A.roundtrip(
-        encode: (A) -> B,
-        decode: (B) -> A,
-        EQ: Eq<A> = Eq.any(),
-        SA: Show<A> = Show.any(),
-        SB: Show<B> = Show.any()
+      encode: (A) -> B,
+      decode: (B) -> A,
+      EQ: Eq<A> = Eq.any(),
+      SA: Show<A> = Show.any(),
+      SB: Show<B> = Show.any()
     ): Kind<M, Unit> = this.roundtrip(
         encode,
         decode.andThen(::Id),
@@ -182,11 +182,11 @@ interface MonadTest<M> : Monad<M> {
     )
 
     fun <A, B> A.roundtripEffect(
-        encode: (A) -> Kind<M, B>,
-        decode: (B) -> Kind<M, A>,
-        EQ: Eq<A> = Eq.any(),
-        SA: Show<A> = Show.any(),
-        SB: Show<B> = Show.any()
+      encode: (A) -> Kind<M, B>,
+      decode: (B) -> Kind<M, A>,
+      EQ: Eq<A> = Eq.any(),
+      SA: Show<A> = Show.any(),
+      SB: Show<B> = Show.any()
     ): Kind<M, Unit> = this.roundtripEffect(
         encode,
         decode.andThen { it.map(::Id) },
@@ -198,21 +198,21 @@ interface MonadTest<M> : Monad<M> {
     )
 
     fun <F, A, B> A.roundtrip(
-        encode: (A) -> B,
-        decode: (B) -> Kind<F, A>,
-        AP: Applicative<F>,
-        EQF: Eq<Kind<F, A>> = Eq.any(),
-        SFA: Show<Kind<F, A>> = Show.any(),
-        SB: Show<B> = Show.any()
+      encode: (A) -> B,
+      decode: (B) -> Kind<F, A>,
+      AP: Applicative<F>,
+      EQF: Eq<Kind<F, A>> = Eq.any(),
+      SFA: Show<Kind<F, A>> = Show.any(),
+      SB: Show<B> = Show.any()
     ): Kind<M, Unit> = roundtripEffect(encode.andThen { just(it) }, decode.andThen { just(it) }, AP, EQF, SFA, SB)
 
     fun <F, A, B> A.roundtripEffect(
-        encode: (A) -> Kind<M, B>,
-        decode: (B) -> Kind<M, Kind<F, A>>,
-        AP: Applicative<F>,
-        EQF: Eq<Kind<F, A>> = Eq.any(),
-        SFA: Show<Kind<F, A>> = Show.any(),
-        SB: Show<B> = Show.any()
+      encode: (A) -> Kind<M, B>,
+      decode: (B) -> Kind<M, Kind<F, A>>,
+      AP: Applicative<F>,
+      EQF: Eq<Kind<F, A>> = Eq.any(),
+      SFA: Show<Kind<F, A>> = Show.any(),
+      SB: Show<B> = Show.any()
     ): Kind<M, Unit> = fx.monad {
         val fa = AP.just(this@roundtripEffect)
         val intermediate = encode(this@roundtripEffect).bind()

--- a/arrow-check/src/main/kotlin/arrow/check/property/Util.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/property/Util.kt
@@ -80,10 +80,10 @@ sealed class JournalEntry {
 }
 
 data class Label<A>(
-    val table: Option<LabelTable>,
-    val name: LabelName,
-    val min: CoverPercentage,
-    val annotation: A
+  val table: Option<LabelTable>,
+  val name: LabelName,
+  val min: CoverPercentage,
+  val annotation: A
 )
 
 inline class CoverPercentage(val unCoverPercentage: Double)
@@ -148,10 +148,10 @@ fun Label<CoverCount>.labelCovered(test: TestCount): Boolean =
 
 @optics
 data class PropertyConfig(
-    val terminationCriteria: TerminationCriteria = NoConfidenceTermination(),
-    val maxDiscardRatio: DiscardRatio = DiscardRatio(10.0),
-    val shrinkLimit: ShrinkLimit = ShrinkLimit(1000),
-    val shrinkRetries: ShrinkRetries = ShrinkRetries(0)
+  val terminationCriteria: TerminationCriteria = NoConfidenceTermination(),
+  val maxDiscardRatio: DiscardRatio = DiscardRatio(10.0),
+  val shrinkLimit: ShrinkLimit = ShrinkLimit(1000),
+  val shrinkRetries: ShrinkRetries = ShrinkRetries(0)
 ) {
     companion object
 }

--- a/arrow-check/src/main/kotlin/arrow/check/property/instances/PropertyT.kt
+++ b/arrow-check/src/main/kotlin/arrow/check/property/instances/PropertyT.kt
@@ -71,8 +71,8 @@ interface PropertyTMonad<M> : Monad<PropertyTPartialOf<M>> {
         }
 
     override fun <A, B> tailRecM(
-        a: A,
-        f: (A) -> Kind<PropertyTPartialOf<M>, Either<A, B>>
+      a: A,
+      f: (A) -> Kind<PropertyTPartialOf<M>, Either<A, B>>
     ): Kind<PropertyTPartialOf<M>, B> =
         f(a).flatMap { it.fold({ tailRecM(it, f) }, { just(it) }) }
 }


### PR DESCRIPTION
Reason: to be able to use a single `.editorconfig` for all the Arrow libraries